### PR TITLE
Update plugin with latest core

### DIFF
--- a/MWPushNotifications/MWPushNotifications/SceneDelegate.swift
+++ b/MWPushNotifications/MWPushNotifications/SceneDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 import MWPushNotificationsPlugin
 import MobileWorkflowCore
 
-class SceneDelegate: MobileWorkflowSceneDelegate {
+class SceneDelegate: MWSceneDelegate {
 
     override func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         

--- a/MWPushNotificationsPlugin/MWPushNotificationsPlugin/MWPushNotificationsPlugin.swift
+++ b/MWPushNotificationsPlugin/MWPushNotificationsPlugin/MWPushNotificationsPlugin.swift
@@ -8,13 +8,13 @@
 import Foundation
 import MobileWorkflowCore
 
-public struct MWPushNotificationsPlugin: MobileWorkflowPlugin {
-    public static var allStepsTypes: [MobileWorkflowStepType] {
+public struct MWPushNotificationsPlugin: Plugin {
+    public static var allStepsTypes: [StepType] {
         return MWPushNotificationsStepType.allCases
     }
 }
 
-public enum MWPushNotificationsStepType: String, MobileWorkflowStepType, CaseIterable {
+public enum MWPushNotificationsStepType: String, StepType, CaseIterable {
     
     case pushNotifications = "io.mobileworkflow.NotificationPermission"
     
@@ -22,7 +22,7 @@ public enum MWPushNotificationsStepType: String, MobileWorkflowStepType, CaseIte
         return self.rawValue
     }
     
-    public var stepClass: MobileWorkflowStep.Type {
+    public var stepClass: BuildableStep.Type {
         switch self {
         case .pushNotifications: return MWPushNotificationsStep.self
         }

--- a/MWPushNotificationsPlugin/MWPushNotificationsPlugin/PushNotificationsStep/MWPushNotificationsStep.swift
+++ b/MWPushNotificationsPlugin/MWPushNotificationsPlugin/PushNotificationsStep/MWPushNotificationsStep.swift
@@ -8,11 +8,11 @@
 import Foundation
 import MobileWorkflowCore
 
-public class MWPushNotificationsStep: ORKStep {
+public class MWPushNotificationsStep: MWStep {
     
-    let services: MobileWorkflowServices
+    let services: StepServices
     
-    init(identifier: String, services: MobileWorkflowServices) {
+    init(identifier: String, services: StepServices) {
         self.services = services
         super.init(identifier: identifier)
     }
@@ -21,13 +21,13 @@ public class MWPushNotificationsStep: ORKStep {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public override func stepViewControllerClass() -> AnyClass {
-        return MWPushNotificationsViewController.self
+    public override func instantiateViewController() -> StepViewController {
+        return MWPushNotificationsViewController(step: self)
     }
 }
 
-extension MWPushNotificationsStep: MobileWorkflowStep {
-    public static func build(stepInfo: StepInfo, services: MobileWorkflowServices) throws -> Step {
+extension MWPushNotificationsStep: BuildableStep {
+    public static func build(stepInfo: StepInfo, services: StepServices) throws -> Step {
         let newStep = MWPushNotificationsStep(identifier: stepInfo.data.identifier, services: services)
         newStep.text = stepInfo.data.content["text"] as? String
         return newStep

--- a/MWPushNotificationsPlugin/MWPushNotificationsPlugin/PushNotificationsStep/MWPushNotificationsViewController.swift
+++ b/MWPushNotificationsPlugin/MWPushNotificationsPlugin/PushNotificationsStep/MWPushNotificationsViewController.swift
@@ -37,14 +37,14 @@ enum MWPushNotificationsError: LocalizedError {
     }
 }
 
-public class MWPushNotificationsViewController: MobileWorkflowButtonViewController {
+public class MWPushNotificationsViewController: MWInstructionStepViewController {
     
     private var registration: AnyCancellable?
     private var pendingDidBecomeActive: AnyCancellable?
     
     private var pushNotificationsStep: MWPushNotificationsStep {
-        guard let pushNotificationsStep = self.step as? MWPushNotificationsStep else {
-            preconditionFailure("Unexpected step type. Expecting \(String(describing: MWPushNotificationsStep.self)), got \(String(describing: type(of: self.step)))")
+        guard let pushNotificationsStep = self.mwStep as? MWPushNotificationsStep else {
+            preconditionFailure("Unexpected step type. Expecting \(String(describing: MWPushNotificationsStep.self)), got \(String(describing: type(of: self.mwStep)))")
         }
         return pushNotificationsStep
     }
@@ -52,14 +52,16 @@ public class MWPushNotificationsViewController: MobileWorkflowButtonViewControll
     public override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.navigationController?.navigationBar.prefersLargeTitles = false
+        
         self.configureWithTitle(
             self.pushNotificationsStep.title ?? "NO_TITLE",
             body: self.pushNotificationsStep.text ?? "NO_TEXT",
-            primaryConfig: .init(title: L10n.PushNotification.enableButtonTitle, action: { [weak self] in
+            primaryConfig: .init(isEnabled: true, style: .primary, title: L10n.PushNotification.enableButtonTitle, action: { [weak self] in
                 guard let strongSelf = self else { return }
                 strongSelf.determineCurrentStatus(completion: strongSelf.resolveStatusBeforeRegistration)
             }),
-            secondaryConfig: .init(title: L10n.PushNotification.skipButtonTitle, action: { [weak self] in
+            secondaryConfig: .init(isEnabled: true, style: .textOnly, title: L10n.PushNotification.skipButtonTitle, action: { [weak self] in
                 guard let strongSelf = self else { return }
                 strongSelf.determineCurrentStatus(completion: strongSelf.resolveStatusAfterUserAction)
             })
@@ -160,8 +162,7 @@ public class MWPushNotificationsViewController: MobileWorkflowButtonViewControll
     private func didReceiveToken(_ token: Data, currentStatus: UNAuthorizationStatus) {
         let stringToken = token.map({ String(format: "%02x", $0) }).joined()
         let result = MWPushNotificationsResult(identifier: self.pushNotificationsStep.identifier, status: currentStatus.name, token: stringToken)
-        self.addResult(result)
-        self.goForward()
+        self.addStepResult(result)
     }
 }
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - MobileWorkflow (0.0.102):
-    - MobileWorkflow/Core (= 0.0.102)
-  - MobileWorkflow/Core (0.0.102)
+  - MobileWorkflow (0.0.117):
+    - MobileWorkflow/Core (= 0.0.117)
+  - MobileWorkflow/Core (0.0.117)
 
 DEPENDENCIES:
   - MobileWorkflow
@@ -11,7 +11,7 @@ SPEC REPOS:
     - MobileWorkflow
 
 SPEC CHECKSUMS:
-  MobileWorkflow: ae04fdf72f704af49de7425a81f0974e1369ef5a
+  MobileWorkflow: efb0ae3619619bcdf66018cb8ec1f2b50bbd85eb
 
 PODFILE CHECKSUM: 93088d90687a33f479985801d17e1d25d1a8f6f1
 


### PR DESCRIPTION
Partially remove exposure to Research Kit with latest core changes.

WIP - Titles are duplicated, since we have Large Titles and `MWInstructionStepViewController` still sets a title. Maybe we could remove `titleLabe` from `configureWithTitle` func?