### PR TITLE
fixed imageURL not appearing

### DIFF
--- a/MWPushNotificationsPlugin.podspec
+++ b/MWPushNotificationsPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWPushNotificationsPlugin'
-    s.version               = '0.0.12'
+    s.version               = '0.0.13'
     s.summary               = 'Push Notifications plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Push Notifications plugin for MobileWorkflow on iOS, to obtain user permission and then APNS token.

--- a/MWPushNotificationsPlugin/MWPushNotificationsPlugin/PushNotificationsStep/MWPushNotificationsStep.swift
+++ b/MWPushNotificationsPlugin/MWPushNotificationsPlugin/PushNotificationsStep/MWPushNotificationsStep.swift
@@ -10,7 +10,7 @@ import MobileWorkflowCore
 
 public class MWPushNotificationsStep: MWStep, InstructionStep {
     
-    public var imageURL: String? { nil }
+    public var imageURL: String?
     public var image: UIImage? { nil }
     public let session: Session
     public let services: StepServices
@@ -34,6 +34,7 @@ extension MWPushNotificationsStep: BuildableStep {
     public static func build(stepInfo: StepInfo, services: StepServices) throws -> Step {
         let newStep = MWPushNotificationsStep(identifier: stepInfo.data.identifier, session: stepInfo.session, services: services)
         newStep.text = stepInfo.data.content["text"] as? String
+        newStep.imageURL = stepInfo.data.content["imageURL"] as? String
         return newStep
     }
 }


### PR DESCRIPTION
[MW-1873]

**imageURL** was not passed to the step builder.

**Steps to test:**

* Add an image to the push notification step

**Expected result:**

Test that image displays

![IMG_8580](https://user-images.githubusercontent.com/1862078/142038023-3d8ba8fa-fcaf-498e-877d-03b559f8e168.PNG)


