### PR TITLE
Convert 'RecurringService' into Async/Await

### DIFF
--- a/MWPushNotificationsPlugin/MWPushNotificationsPlugin/Services/Recurring/RecurringService.swift
+++ b/MWPushNotificationsPlugin/MWPushNotificationsPlugin/Services/Recurring/RecurringService.swift
@@ -29,23 +29,19 @@ extension RecurringService: AsyncTaskService {
         || task is RecurringCancelTask
     }
     
-    public func perform<T>(task: T, session: ContentProvider, respondOn: DispatchQueue, completion: @escaping (Result<T.Response, Error>) -> Void) where T : AsyncTask {
-        if let task = task as? RecurringCreateTask,
-           let completion = completion as? ((Result<RecurringCreateTask.Response, Error>) -> Void) {
-            self.perform(task: task, session: session, respondOn: respondOn, completion: completion)
-        } else if let task = task as? RecurringCancelTask,
-                  let completion = completion as? ((Result<RecurringCancelTask.Response, Error>) -> Void) {
-            self.perform(task: task, session: session, respondOn: respondOn, completion: completion)
+    func perform<T>(task: T, session: ContentProvider) async throws -> T.Response where T : AsyncTask {
+        if let task = task as? RecurringCreateTask {
+            return try await self.performRecurring(task: task, session: session) as! T.Response
+        } else if let task = task as? RecurringCancelTask {
+            return try await self.performCancel(task: task, session: session) as! T.Response
         } else {
-            self.notify(result: .failure(ServiceError.cannotPerformTask), on: respondOn, completion: completion)
+            throw ServiceError.cannotPerformTask
         }
     }
     
-    func perform(task: RecurringCreateTask, session: ContentProvider, respondOn: DispatchQueue, completion: @escaping (Result<RecurringCreateTask.Response, Error>) -> Void) {
-        
+    func performRecurring(task: RecurringCreateTask, session: ContentProvider) async throws -> RecurringCreateTask.Response {
         guard let rrule = RRule(rrule: task.input.recurrenceRule) else {
-            self.notify(result: .failure(ParseError.invalidStepData(cause: "Invalid RRULE")), on: respondOn, completion: completion)
-            return
+            throw ParseError.invalidStepData(cause: "Invalid RRULE")
         }
         
         let triggers = rrule.notificationTriggers().prefix(10)
@@ -54,34 +50,46 @@ extension RecurringService: AsyncTaskService {
         
         if triggers.count > 0 {
             notificationCenter.removeAllPendingNotificationRequests()
+        } else {
+            return true
         }
         
-        for trigger in triggers {
-            var notificationContent = UNMutableNotificationContent()
-            notificationContent.title = task.input.notificationTitle ?? ""
-            notificationContent.body = task.input.notificationText ?? ""
-            
-            let notificationRequest = UNNotificationRequest(identifier: UUID().uuidString,
-                                                            content: notificationContent,
-                                                            trigger: trigger)
-            notificationCenter.add(notificationRequest) { error in
-                if let error = error {
-                    self.notify(result: .failure(error), on: respondOn, completion: completion)
-                } else {
-                    print("added notification trigger at \(trigger.dateComponents)")
+        
+        return try await withThrowingTaskGroup(of: Bool.self) { group in
+            for trigger in triggers {
+                var notificationContent = UNMutableNotificationContent()
+                notificationContent.title = task.input.notificationTitle ?? ""
+                notificationContent.body = task.input.notificationText ?? ""
+                
+                let notificationRequest = UNNotificationRequest(identifier: UUID().uuidString,
+                                                                content: notificationContent,
+                                                                trigger: trigger)
+                
+                group.addTask {
+                    try await withCheckedThrowingContinuation { continuation in
+                        notificationCenter.add(notificationRequest) { error in
+                            if let error = error {
+                                continuation.resume(throwing: error)
+                            } else {
+                                continuation.resume(returning: true)
+                            }
+                        }
+                    }
                 }
             }
+            
+            var response = true
+            for try await taskResponse in group {
+                response = taskResponse && response
+            }
+            return response
         }
-        
-        self.notify(result: .success(true), on: respondOn, completion: completion)
     }
     
-    func perform(task: RecurringCancelTask, session: ContentProvider, respondOn: DispatchQueue, completion: @escaping (Result<RecurringCancelTask.Response, Error>) -> Void) {
-        
+    func performCancel(task: RecurringCancelTask, session: ContentProvider) async throws -> RecurringCancelTask.Response {
         let notificationCenter: UNUserNotificationCenter = .current()
         notificationCenter.removeAllPendingNotificationRequests()
-        
-        self.notify(result: .success(true), on: respondOn, completion: completion)
+        return true
     }
     
 }


### PR DESCRIPTION
### Feature/Issue

With the update of the project structure, the services need to be updated to use Async/Await APIs

### Implementation

Convert closure-based methods into Async/Await.

### Notes

In this update, if any of the notification registers throws, the whole process stops, throwing. It is possible to 'continue' on error, if we want to, by modifying this for each:

```swift
var response = true
for try await taskResponse in group {
    response = taskResponse && response
}
return response
```