### PR TITLE
[iOS] [Notifications] Play default notification sound for local notifications

### DIFF
--- a/MWPushNotificationsPlugin/MWPushNotificationsPlugin/Services/Recurring/RecurringService.swift
+++ b/MWPushNotificationsPlugin/MWPushNotificationsPlugin/Services/Recurring/RecurringService.swift
@@ -63,6 +63,7 @@ extension RecurringService: AsyncTaskService {
             var notificationContent = UNMutableNotificationContent()
             notificationContent.title = notificationTitle
             notificationContent.body = notificationBody
+            notificationContent.sound = .default
             
             let notificationRequest = UNNotificationRequest(identifier: UUID().uuidString,
                                                             content: notificationContent,


### PR DESCRIPTION
<!-- TITLE OF THE PR: For the title, if there is an associated task/todo/pitch, please create the PR with the task name. Example: [iOS] Empty view behaviour -->

### Task

<!-- Please, add here links to the task/pitch/todo/thread that triggered this Pull Request. Example: [[iOS] Empty view behaviour](https://3.basecamp.com/5245563/buckets/26145695/todos/4882286741) -->

[[iOS] [Notifications] Play default notification sound for local notifications](https://3.basecamp.com/5245563/buckets/26145695/todos/5375978052)

### Feature/Issue

<!-- Please describe in short terms what is the scope of the feature or what is the bug that is being fixed -->

Local notification should play the default notification sound.
It currently plays no sound.

### Implementation

<!-- Please describe the general idea of what was implemented. Comments that may help your peer reviewer. Things like: architectural details, points of attention, etc. -->

### Notes

<!-- If there is any test step, or consideration about the feature, please, add it here. This may include prints/videos of the feature in action. -->