### PR TITLE
Allow user to modify text button texts when requesting Push Notification

### DIFF
--- a/MWPushNotificationsPlugin.podspec
+++ b/MWPushNotificationsPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWPushNotificationsPlugin'
-    s.version               = '0.2.3'
+    s.version               = '0.2.4'
     s.summary               = 'Push Notifications plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Push Notifications plugin for MobileWorkflow on iOS, to obtain user permission and then APNS token.

--- a/MWPushNotificationsPlugin/MWPushNotificationsPlugin/Steps/Push Notifications/MWPushNotificationsStep.swift
+++ b/MWPushNotificationsPlugin/MWPushNotificationsPlugin/Steps/Push Notifications/MWPushNotificationsStep.swift
@@ -11,15 +11,21 @@ import UIKit
 
 public class MWPushNotificationsStep: MWStep, InstructionStep {
     
-    public var imageURL: String?
+    public let imageURL: String?
     public var image: UIImage? { nil }
     public let session: Session
     public let services: StepServices
+    public let enableText: String?
+    public let skipText: String?
     
-    init(identifier: String, session: Session, services: StepServices) {
+    init(identifier: String, text: String?, imageURL: String?, enableText: String?, skipText: String?, session: Session, services: StepServices) {
         self.session = session
         self.services = services
+        self.enableText = enableText
+        self.skipText = skipText
+        self.imageURL = imageURL
         super.init(identifier: identifier)
+        self.text = text
     }
     
     required init(coder aDecoder: NSCoder) {
@@ -36,9 +42,14 @@ extension MWPushNotificationsStep: BuildableStep {
     public static var mandatoryCodingPaths: [CodingKey] { [] }
     
     public static func build(stepInfo: StepInfo, services: StepServices) throws -> Step {
-        let newStep = MWPushNotificationsStep(identifier: stepInfo.data.identifier, session: stepInfo.session, services: services)
-        newStep.text = stepInfo.data.content["text"] as? String
-        newStep.imageURL = stepInfo.data.content["imageURL"] as? String
-        return newStep
+        MWPushNotificationsStep(
+            identifier: stepInfo.data.identifier,
+            text: stepInfo.data.content["text"] as? String,
+            imageURL: stepInfo.data.content["imageURL"] as? String,
+            enableText: stepInfo.data.content["enableText"] as? String,
+            skipText: stepInfo.data.content["skipText"] as? String,
+            session: stepInfo.session,
+            services: services
+        )
     }
 }

--- a/MWPushNotificationsPlugin/MWPushNotificationsPlugin/Steps/Push Notifications/MWPushNotificationsStep.swift
+++ b/MWPushNotificationsPlugin/MWPushNotificationsPlugin/Steps/Push Notifications/MWPushNotificationsStep.swift
@@ -9,22 +9,18 @@ import Foundation
 import MobileWorkflowCore
 import UIKit
 
-public class MWPushNotificationsStep: MWStep, InstructionStep {
+public class MWPushNotificationsStep: ObservableStep, InstructionStep {
     
     public let imageURL: String?
     public var image: UIImage? { nil }
-    public let session: Session
-    public let services: StepServices
     public let enableText: String?
     public let skipText: String?
     
     init(identifier: String, text: String?, imageURL: String?, enableText: String?, skipText: String?, session: Session, services: StepServices) {
-        self.session = session
-        self.services = services
         self.enableText = enableText
         self.skipText = skipText
         self.imageURL = imageURL
-        super.init(identifier: identifier)
+        super.init(identifier: identifier, session: session, services: services)
         self.text = text
     }
     

--- a/MWPushNotificationsPlugin/MWPushNotificationsPlugin/Steps/Push Notifications/MWPushNotificationsViewController.swift
+++ b/MWPushNotificationsPlugin/MWPushNotificationsPlugin/Steps/Push Notifications/MWPushNotificationsViewController.swift
@@ -34,20 +34,20 @@ public class MWPushNotificationsViewController: MWInstructionStepViewController 
         self.mwStep as! MWPushNotificationsStep
     }
     private var enableText: String {
-        self.pushNotificationsStep.session.resolve(
-            value: self.pushNotificationsStep.enableText ?? L10n.PushNotification.enableButtonTitle
+        self.pushNotificationsStep.resolve(
+            self.pushNotificationsStep.enableText ?? L10n.PushNotification.enableButtonTitle
         )
     }
     private var skipText: String {
-        self.pushNotificationsStep.session.resolve(
-            value: self.pushNotificationsStep.skipText ?? L10n.PushNotification.skipButtonTitle
+        self.pushNotificationsStep.resolve(
+            self.pushNotificationsStep.skipText ?? L10n.PushNotification.skipButtonTitle
         )
     }
     private var stepTitle: String {
-        self.pushNotificationsStep.session.resolve(value: self.pushNotificationsStep.title ?? "NO_TITLE")
+        self.pushNotificationsStep.resolve(self.pushNotificationsStep.title ?? "NO_TITLE")
     }
     private var stepText: String {
-        self.pushNotificationsStep.session.resolve(value: self.pushNotificationsStep.text ?? "NO_TEXT")
+        self.pushNotificationsStep.resolve(self.pushNotificationsStep.text ?? "NO_TEXT")
     }
     
     public override func viewDidLoad() {

--- a/MWPushNotificationsPlugin/MWPushNotificationsPlugin/Steps/Push Notifications/MWPushNotificationsViewController.swift
+++ b/MWPushNotificationsPlugin/MWPushNotificationsPlugin/Steps/Push Notifications/MWPushNotificationsViewController.swift
@@ -33,18 +33,34 @@ public class MWPushNotificationsViewController: MWInstructionStepViewController 
     private var pushNotificationsStep: MWPushNotificationsStep {
         self.mwStep as! MWPushNotificationsStep
     }
+    private var enableText: String {
+        self.pushNotificationsStep.session.resolve(
+            value: self.pushNotificationsStep.enableText ?? L10n.PushNotification.enableButtonTitle
+        )
+    }
+    private var skipText: String {
+        self.pushNotificationsStep.session.resolve(
+            value: self.pushNotificationsStep.skipText ?? L10n.PushNotification.skipButtonTitle
+        )
+    }
+    private var stepTitle: String {
+        self.pushNotificationsStep.session.resolve(value: self.pushNotificationsStep.title ?? "NO_TITLE")
+    }
+    private var stepText: String {
+        self.pushNotificationsStep.session.resolve(value: self.pushNotificationsStep.text ?? "NO_TEXT")
+    }
     
     public override func viewDidLoad() {
         super.viewDidLoad()
         
         self.configureWithTitle(
-            self.pushNotificationsStep.title ?? "NO_TITLE",
-            body: self.pushNotificationsStep.text ?? "NO_TEXT",
-            primaryConfig: .init(isEnabled: true, style: .primary, title: L10n.PushNotification.enableButtonTitle, action: { [weak self] in
+            self.stepTitle,
+            body: self.stepText,
+            primaryConfig: .init(isEnabled: true, style: .primary, title: self.enableText, action: { [weak self] in
                 guard let strongSelf = self else { return }
                 strongSelf.determineCurrentStatus(completion: strongSelf.resolveStatusBeforeRegistration)
             }),
-            secondaryConfig: .init(isEnabled: true, style: .textOnly, title: L10n.PushNotification.skipButtonTitle, action: { [weak self] in
+            secondaryConfig: .init(isEnabled: true, style: .textOnly, title: self.skipText, action: { [weak self] in
                 guard let strongSelf = self else { return }
                 strongSelf.determineCurrentStatus(completion: strongSelf.resolveStatusAfterUserAction)
             })


### PR DESCRIPTION
### Task

[[ARP Bug][Medium]Android notification permissions screen missing Enable / Skip](https://3.basecamp.com/5245563/buckets/26145695/card_tables/cards/5509665232)

### Feature/Issue

> Additional client feedback is that the wording of the 2 buttons should be “Enable” and “Disable” (instead of “Skip”).

### Implementation

Allow the user to configure the UI button text by having the text for these buttons come from the step configuration. Also, the texts being presented are being translated now.

### UI

<table>
<th>Configuration</th><th>Screen</th>

<tr><td><img width="300" alt="Screenshot 2022-11-25 at 12 03 10" src="https://user-images.githubusercontent.com/2117340/203979625-c5646660-5f41-49e4-8761-f16fcf565b4a.png"/></td>

<td><img width="200" src="https://user-images.githubusercontent.com/2117340/203979634-b1849478-06f8-4c02-92d5-4736eecdcd06.PNG"/></td></tr>
</table>

